### PR TITLE
GitHub Actions lint, test, and publish

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,11 +1,11 @@
 module.exports = {
   env: {
-    node: true,
+    node: true
   },
   extends: [
     'eslint:recommended',
     'eslint-config-standard',
-    'plugin:vue/vue3-essential',
+    'plugin:vue/vue3-essential'
   ],
   // add your custom rules here
   rules: {
@@ -16,6 +16,6 @@ module.exports = {
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
     // ignore component name multiword rule
-    'vue/multi-word-component-names': 0,
+    'vue/multi-word-component-names': 0
   }
 }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: '20.x'
       - run: npm ci
       - run: npm run lint
       - run: npm run test
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: '20.x'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm lint
-      - run: npm test
+      - run: npm run lint
+      - run: npm run test
   
   publish-npm:
     needs: build

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,31 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm lint
+      - run: npm test
+  
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/run-vitest.yml
+++ b/.github/workflows/run-vitest.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: '20.x'
       - run: npm ci
       - run: npm run lint
       - run: npm run test

--- a/.github/workflows/run-vitest.yml
+++ b/.github/workflows/run-vitest.yml
@@ -1,0 +1,13 @@
+name: Run linter and unit tests
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm lint
+      - run: npm test

--- a/.github/workflows/run-vitest.yml
+++ b/.github/workflows/run-vitest.yml
@@ -9,5 +9,5 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm lint
-      - run: npm test
+      - run: npm run lint
+      - run: npm run test

--- a/src/Demo.vue
+++ b/src/Demo.vue
@@ -284,7 +284,7 @@ export default {
       },
       highlighted: {},
       eventMsg: null,
-      state: state,
+      state,
       vModelExample: null,
       languages: lang,
       language: 'en'
@@ -320,7 +320,7 @@ export default {
       if (elem.target.value === 'undefined') {
         return
       }
-      let highlightedDays = elem.target.value.split(',').map(day => parseInt(day))
+      const highlightedDays = elem.target.value.split(',').map(day => parseInt(day))
       this.highlighted = {
         from: this.highlighted.from,
         to: this.highlighted.to,
@@ -331,7 +331,7 @@ export default {
       if (elem.target.value === 'undefined') {
         return
       }
-      let disabledDays = elem.target.value.split(',').map(day => parseInt(day))
+      const disabledDays = elem.target.value.split(',').map(day => parseInt(day))
       this.disabledDates = {
         from: this.disabledDates.from,
         to: this.disabledDates.to,

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,4 +1,4 @@
 import { createApp } from 'vue'
 import Demo from './Demo.vue'
 
-createApp(Demo).mount('#app');
+createApp(Demo).mount('#app')

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "env": {
-    "jest": true
-  },
-  "globals": {
-    "expect": true,
-    "sinon": true
-  }
-}

--- a/test/.eslintrc.cjs
+++ b/test/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  env: {
+    jest: true
+  },
+  globals: {
+    expect: true,
+    vi: true
+  }
+}

--- a/test/DateInput/DateInput.test.js
+++ b/test/DateInput/DateInput.test.js
@@ -3,18 +3,6 @@ import { shallowMount } from '@vue/test-utils'
 import { en } from '@/locale'
 
 describe('DateInput', () => {
-  let vm
-
-  beforeEach(() => {
-    vm = shallowMount(DateInput, {
-      props: {
-        selectedDate: new Date(2018, 2, 24),
-        format: 'dd MMM yyyy',
-        translation: en
-      }
-    })
-  })
-
   it('should render correct contents', () => {
     const wrapper = shallowMount(DateInput, {
       props: {

--- a/test/Datepicker/Datepicker.test.js
+++ b/test/Datepicker/Datepicker.test.js
@@ -1,6 +1,6 @@
 import Datepicker from '@/components/Datepicker.vue'
 import DateInput from '@/components/DateInput.vue'
-import { nextTick } from 'vue';
+import { nextTick } from 'vue'
 import { shallowMount, mount } from '@vue/test-utils'
 
 describe('Datepicker unmounted', () => {


### PR DESCRIPTION
Adds GitHub Actions workflows:
- run-vitest.yml - on push, runs npm lint && npm test
- npc-publish - on created release, runs npm lint && npm test && npm publish

Additionally, eslint was broken due to swapping to `"type": "module"` in `package.json`, fixed with renaming `.eslintrc.js` to `.eslintrc.cjs`